### PR TITLE
Compatibility with python>=3.8 and pymanopt new API

### DIFF
--- a/RELMM.py
+++ b/RELMM.py
@@ -33,10 +33,11 @@ sphere.
 """
 
 import numpy as np
+import pymanopt
 from proj_simplex import proj_simplex
 from pymanopt.manifolds import Oblique
 from pymanopt import Problem
-from pymanopt.solvers import ConjugateGradient
+from pymanopt.optimizers import ConjugateGradient
 
 def RELMM(data,A_init,S0,lambda_S,lambda_S0):   
     
@@ -47,6 +48,7 @@ def RELMM(data,A_init,S0,lambda_S,lambda_S0):
     V = P*np.eye(P) - np.outer(np.ones(P),np.transpose(np.ones(P)))    
     
     
+    @pymanopt.function.numpy(Oblique(L, P))
     def cost(X):
 
         data_fit = np.zeros(N)    
@@ -58,6 +60,7 @@ def RELMM(data,A_init,S0,lambda_S,lambda_S0):
 
         return cost        
         
+    @pymanopt.function.numpy(Oblique(L, P))
     def egrad(X):
 
         partial_grad = np.zeros([L,P,N])    
@@ -137,8 +140,8 @@ def RELMM(data,A_init,S0,lambda_S,lambda_S0):
 
         manifold = Oblique(L, P)
         solver = ConjugateGradient()
-        problem = Problem(manifold=manifold, cost=cost, egrad = egrad)
-        S0 = solver.solve(problem)   
+        problem = Problem(manifold=manifold, cost=cost, euclidean_gradient=egrad)
+        S0 = solver.run(problem).point
    
 # termination checks    
 

--- a/demo_ELMM.py
+++ b/demo_ELMM.py
@@ -80,9 +80,9 @@ imr = np.transpose(im.reshape((N,L),order='F'))
 
 # unmixing with SCLSU
 
-start = time.clock()
+start = time.perf_counter()
 [A_SCLSU,psi_SCLSU,S_SCLSU] = SCLSU(imr,S0)
-end = time.clock()
+end = time.perf_counter()
 print(end - start)
 
 


### PR DESCRIPTION
Compatibility with python>=3.8:

- ["The function time.clock() has been removed"](https://docs.python.org/3/whatsnew/3.8.html#api-and-feature-removals)
  - `time.clock()` → `time.perf_counter()`

Compatibility with pymanopt new API:
- [`pymanopt.optimizers.optimizer.Optimizer`](https://pymanopt.org/docs/stable/optimizers.html?highlight=conjugategradient#pymanopt.optimizers.optimizer.Optimizer)
  - `pymanopt.solvers` → `pymanopt.optimizers`
  - `solver.solve(problem)` → `solver.run(problem).point`
- [`pymanopt.core.problem.Problem`](https://pymanopt.org/docs/stable/problem.html#pymanopt.core.problem.Problem)
  - `Problem(..., egrad=...)` → `Problem(..., euclidean_gradient=...)`
  - decorate `Problem`s `cost` and `eucliden_gradient` into `pymanopt.autodiff.Function`s.